### PR TITLE
fix pair memory leak

### DIFF
--- a/app/src/main/java/com/bullfrog/particle/MainActivity.kt
+++ b/app/src/main/java/com/bullfrog/particle/MainActivity.kt
@@ -67,12 +67,17 @@ class MainActivity : AppCompatActivity() {
             val cos = Random.nextDouble(-1.0, 1.0)
             val sin = Random.nextDouble(-1.0, 1.0)
 
-            override fun getCurrentCoord(progress: Float, duration: Long): Pair<Int, Int> {
+            override fun getCurrentCoord(
+                progress: Float,
+                duration: Long,
+                outCoord: IntArray
+            ): Unit {
                 val originalX = distance * progress
                 val originalY = 100 * sin(originalX / 50)
                 val x = originalX * cos - originalY * sin
                 val y = originalX * sin + originalY * cos
-                return Pair((0.01 * x * originalY).toInt(), -(0.0001 * y.pow(2) * originalX).toInt())
+                outCoord[0] = (0.01 * x * originalY).toInt()
+                outCoord[1] = -(0.0001 * y.pow(2) * originalX).toInt()
             }
         }
     }

--- a/particlelib/src/main/java/com/bullfrog/particle/animator/ParticleAnimator.kt
+++ b/particlelib/src/main/java/com/bullfrog/particle/animator/ParticleAnimator.kt
@@ -26,12 +26,13 @@ class ParticleAnimator(
     private fun initAnimator() {
         animator = animation.createAnimator()
         val duration = animator!!.duration
+        val coords = IntArray(2)
         animator!!.addUpdateListener { animator ->
             val progress = animator.animatedFraction
             paticles.forEach {
-                val coords = it.pathGenerator?.getCurrentCoord(progress, duration)
-                it.x = it.initialX + (coords?.first ?: 0)
-                it.y = it.initialY + (coords?.second ?: 0)
+                it.pathGenerator?.getCurrentCoord(progress, duration, coords)
+                it.x = it.initialX + coords[0]
+                it.y = it.initialY + coords[1]
 
                 val rotation = it.configuration!!.rotation
                 val sign = if (rotation.rotationDirection == RotationDirection.ClockWise) 1 else -1

--- a/particlelib/src/main/java/com/bullfrog/particle/path/FallPathGenerator.kt
+++ b/particlelib/src/main/java/com/bullfrog/particle/path/FallPathGenerator.kt
@@ -8,8 +8,9 @@ open class FallPathGenerator : LinearPathGenerator() {
 
     open val x = Random.nextInt(-300, 300)
 
-    override fun getCurrentCoord(progress: Float, duration: Long): Pair<Int, Int> {
+    override fun getCurrentCoord(progress: Float, duration: Long, outCoord: IntArray): Unit {
         val coordY = progress * distance
-        return Pair(x, coordY.toInt())
+        outCoord[0] = x
+        outCoord[1] = coordY.toInt()
     }
 }

--- a/particlelib/src/main/java/com/bullfrog/particle/path/FireWorkPathGenerator.kt
+++ b/particlelib/src/main/java/com/bullfrog/particle/path/FireWorkPathGenerator.kt
@@ -23,10 +23,11 @@ open class FireWorkPathGenerator : IPathGenerator {
         initVelocityY = initVelocity * sin(theta)
     }
 
-    override fun getCurrentCoord(progress: Float, duration: Long): Pair<Int, Int> {
+    override fun getCurrentCoord(progress: Float, duration: Long, outCoord: IntArray): Unit {
         val t = duration * progress / 1000
         val x = initVelocityX * t
         val y = initVelocityY * t - 0.5f * gravity * t.pow(2)
-        return Pair(x.toInt(), -y.toInt())
+        outCoord[0] = x.toInt()
+        outCoord[1] = -y.toInt()
     }
 }

--- a/particlelib/src/main/java/com/bullfrog/particle/path/IPathGenerator.kt
+++ b/particlelib/src/main/java/com/bullfrog/particle/path/IPathGenerator.kt
@@ -2,6 +2,6 @@ package com.bullfrog.particle.path
 
 interface IPathGenerator {
 
-    fun getCurrentCoord(progress: Float, duration: Long): Pair<Int, Int>
+    fun getCurrentCoord(progress: Float, duration: Long, outCoord: IntArray)
 
 }

--- a/particlelib/src/main/java/com/bullfrog/particle/path/LinearPathGenerator.kt
+++ b/particlelib/src/main/java/com/bullfrog/particle/path/LinearPathGenerator.kt
@@ -11,10 +11,11 @@ open class LinearPathGenerator: IPathGenerator {
 
     open val theta = Random.nextDouble(2 * PI)
 
-    override fun getCurrentCoord(progress: Float, duration: Long): Pair<Int, Int> {
+    override fun getCurrentCoord(progress: Float, duration: Long, outCoord: IntArray): Unit {
         val coordX = distance * progress * cos(theta)
         val coordY = distance * progress * sin(theta)
-        return Pair(coordX.toInt(), coordY.toInt())
+        outCoord[0] = coordX.toInt()
+        outCoord[1] = coordY.toInt()
     }
 
 }

--- a/particlelib/src/main/java/com/bullfrog/particle/path/RisePathGenerator.kt
+++ b/particlelib/src/main/java/com/bullfrog/particle/path/RisePathGenerator.kt
@@ -8,8 +8,9 @@ open class RisePathGenerator : LinearPathGenerator() {
 
     open val x = Random.nextInt(-300, 300)
 
-    override fun getCurrentCoord(progress: Float, duration: Long): Pair<Int, Int> {
+    override fun getCurrentCoord(progress: Float, duration: Long, outCoord: IntArray): Unit {
         val coordY = progress * distance
-        return Pair(x, coordY.toInt())
+        outCoord[0] = x
+        outCoord[1] = coordY.toInt()
     }
 }


### PR DESCRIPTION
Creating new `Pair` object during `onDraw` method on each partical in animator update listener is causing memory leaks and crash after running for minutes